### PR TITLE
Password reset via email

### DIFF
--- a/common/templates/new_password_reset.html
+++ b/common/templates/new_password_reset.html
@@ -1,0 +1,37 @@
+{% extends 'root_email_template_new.html' %}
+
+{% block heading %}
+Hi {{user_email}}
+{% endblock heading %}
+
+{% block content_body %}
+You can use the following link to reset your password. 
+
+
+{% endblock content_body %}
+
+{% block button_link %}
+<a href="{{complete_url}}"
+  style="display: inline-block; background: #2dc24d; font-size: 20px;font-weight: 500;color:#fff;width: 255px;text-align: center;padding: 18px 0;border-radius:4px;text-decoration: none;">
+  Verify Your Email</a>
+{% endblock button_link %}
+
+
+{% block extra_content %}
+<tr>
+  <td style="text-align:center;padding:25px 75px;font-weight: 300;color:#000000;font-size:37px;">
+    This link will be valid for 1 hours.
+  </td>
+</tr>
+
+{% endblock extra_content %}
+
+{% comment %}
+<div style="margin-bottom:20px"><a href="{{complete_url}}"
+    style="display:inline-block;width:170px;background:#38abdd;padding:10px;text-align:center;color:#fff;font-size:1rem;font-weight:600;margin:0px auto;margin-bottom:20px;border-radius:5px;text-decoration:none;display:block">Click
+    Here to Activate your Account</a>
+</div>
+<div style="margin-bottom:20px"><a href="{{url}}"
+    style="display:inline-block;width:170px;background:#38abdd;padding:10px;text-align:center;color:#fff;font-size:1rem;font-weight:600;margin:0px auto;margin-bottom:20px;border-radius:5px;text-decoration:none;display:block">Login</a>
+</div>
+{% endcomment %}

--- a/common/templates/password_reset_email.html
+++ b/common/templates/password_reset_email.html
@@ -7,8 +7,9 @@ Hi {{email}}
 
 {% ifequal 'activated' message %}
 {% block content_body %}
-Your account has been activated by {{status_changed_user}}. You can login to your account and access all the features of
-Django CRM.
+You can use the following link to reset your password. This link will expire in 1 hours.
+
+{% if url %}
 {% endblock content_body %}
 {% block button_link %}
 {% if url %}

--- a/common/urls.py
+++ b/common/urls.py
@@ -3,10 +3,13 @@ from rest_framework_simplejwt import views as jwt_views
 
 from common import views
 
+
 app_name = "api_common"
 
 
 urlpatterns = [
+    path('reset-password/', views.PasswordResetRequestView.as_view(), name='password-reset'),
+    path('reset-password-confirm/', views.PasswordResetConfirmView.as_view(), name='password-reset-confirm'),
     path("auth/activate-user/", views.UserActivate.as_view()),
     path("auth/login/", views.CustomLoginView.as_view(), name="login"),
     path("dashboard/", views.ApiHomeView.as_view()),

--- a/common/views.py
+++ b/common/views.py
@@ -1061,5 +1061,21 @@ class UserActivate(APIView):
         user.save()
 
         return Response({"detail": "Password set and account activated"}, status=200)
-
+class PasswordResetRequestView(APIView):
+    @extend_schema(request= PasswordResetRequestSerializer)
         
+    def post(self, request):
+        serializer = PasswordResetRequestSerializer(data=request.data, context={'request': request})
+        if serializer.is_valid():
+            serializer.save()
+            return Response({"message": "Password reset email sent."}, status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        
+class PasswordResetConfirmView(APIView):
+    @extend_schema(request=PasswordResetConfirmSerializer)
+    def post(self, request):
+        serializer = PasswordResetConfirmSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response({"message": "Password has been reset."}, status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
api/reset-password and api/reset-password-confirm has been created. To realize this,
-  Two serialiazers are added  to common/serialiazers.py, PasswordResetRequestSerializer and PasswordResetConfirmSerializer
-  Two classes are added to common/views.py, 
       - PasswordResetRequestView, sends password reset link to user's email.
       - PasswordResetConfirmView, confirms the password reset and save the new password in to the database( after checking the 
          expiration time and if the link is already used or not).
- The default expiration time is changed to 1 hr in the common/tasks.py.
- New html file is added to templates, new_password_reset.html, to style the password reset email message.
